### PR TITLE
Show wired connections as Wired

### DIFF
--- a/src/Widgets/EtherInterface.vala
+++ b/src/Widgets/EtherInterface.vala
@@ -54,7 +54,7 @@ namespace Network.Widgets {
                 display_title = _("Virtual network: %s").printf (name);
             } else {
                 if (count <= 1) {
-                    display_title = _("Ethernet");
+                    display_title = _("Wired");
                 } else {
                     display_title = name;
                 }


### PR DESCRIPTION
Currently we assume all wired connections are Ethernet connections. This is not always true however, as my USB tethered phone is also a wired connection. Instead, we should use the generic term "Wired" which covers the connection type without implying the use of Ethernet specifically