### PR TITLE
WidgetNMInterface: remove display_title property

### DIFF
--- a/src/Views/EthernetPage.vala
+++ b/src/Views/EthernetPage.vala
@@ -52,12 +52,12 @@ namespace Network.Widgets {
 
             /* At least for docker related interfaces, which can be fairly common */
             if (name.has_prefix ("veth")) {
-                display_title = _("Virtual network: %s").printf (name);
+                title = _("Virtual network: %s").printf (name);
             } else {
                 if (count <= 1) {
-                    display_title = _("Wired");
+                    title = _("Wired");
                 } else {
-                    display_title = name;
+                    title = name;
                 }
             }
         }

--- a/src/Views/HotspotPage.vala
+++ b/src/Views/HotspotPage.vala
@@ -74,10 +74,10 @@
 
         public override void update_name (int count) {
             if (count <= 1) {
-                display_title = _("Hotspot");
+                title = _("Hotspot");
             }
             else {
-                display_title = _("Hotspot %s").printf (device.get_description ());
+                title = _("Hotspot %s").printf (device.get_description ());
             }
         }
 

--- a/src/Views/ModemPage.vala
+++ b/src/Views/ModemPage.vala
@@ -53,15 +53,15 @@ namespace Network.Widgets {
                 if (count > 1) {
                     var name = device.get_description ();
                     if (NM.DeviceModemCapabilities.POTS in capabilities) {
-                        display_title = _("Modem: %s").printf (name);
+                        title = _("Modem: %s").printf (name);
                     } else {
-                        display_title = _("Mobile Broadband: %s").printf (name);
+                        title = _("Mobile Broadband: %s").printf (name);
                     }
                 } else {
                     if (NM.DeviceModemCapabilities.POTS in capabilities) {
-                        display_title = _("Modem");
+                        title = _("Modem");
                     } else {
-                        display_title = _("Mobile Broadband");
+                        title = _("Mobile Broadband");
                     }
                 }
             } else {

--- a/src/Views/WifiPage.vala
+++ b/src/Views/WifiPage.vala
@@ -182,9 +182,9 @@ namespace Network {
 
         public override void update_name (int count) {
             if (count <= 1) {
-                display_title = _("Wireless");
+                title = _("Wireless");
             } else {
-                display_title = device.get_description ();
+                title = device.get_description ();
             }
         }
 

--- a/src/Widgets/DeviceItem.vala
+++ b/src/Widgets/DeviceItem.vala
@@ -46,7 +46,7 @@ namespace Network.Widgets {
 
             this.page = iface;
             this.device = iface.device;
-            iface.bind_property ("display-title", this, "title");
+            iface.bind_property ("title", this, "title");
 
             switch_status (Utils.CustomMode.INVALID, iface.state);
             iface.notify["state"].connect (() => {

--- a/src/Widgets/Page.vala
+++ b/src/Widgets/Page.vala
@@ -30,6 +30,8 @@ namespace Network.Widgets {
 
             if (device != null) {
                 title = Utils.type_to_string (device.get_device_type ());
+            } else if (title == null){
+                title = _("Unknown Device");
             }
 
             update_switch ();

--- a/src/Widgets/WidgetNMInterface.vala
+++ b/src/Widgets/WidgetNMInterface.vala
@@ -18,12 +18,6 @@
 public abstract class Network.WidgetNMInterface : Network.Widgets.Page {
     public Network.State state { get; protected set; default = Network.State.DISCONNECTED; }
 
-    public string display_title { get; protected set; default = _("Unknown device"); }
-
-    construct {
-        bind_property ("display-title", this, "title");
-    }
-
     public bool is_device (NM.Device device) {
         return device == this.device;
     }
@@ -33,6 +27,6 @@ public abstract class Network.WidgetNMInterface : Network.Widgets.Page {
     }
 
     public virtual void update_name (int count) {
-        display_title = _("Unknown type: %s ").printf (device.get_description ());
+        title = _("Unknown type: %s ").printf (device.get_description ());
     }
 }


### PR DESCRIPTION
* Use existing title property for setting page titles and reading them in the sidebar
* Set title to "Unknown Device" in Page whenever title is null. Preserves functionality