### PR TITLE
 build: fix install path for switchboard plug

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -2,6 +2,6 @@ i18n.merge_file(
     input: 'io.elementary.switchboard.network.appdata.xml.in',
     output: 'io.elementary.switchboard.network.appdata.xml',
     po_dir: join_paths(meson.source_root (), 'po', 'extra'),
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    install_dir: join_paths(datadir, 'metainfo'),
     install: true
 )

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,10 @@ gettext_name = meson.project_name() + '-plug'
 gnome = import('gnome')
 i18n = import('i18n')
 
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),
     language:'c'

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,7 @@ plug_files = files(
 )
 
 switchboard_dep = dependency('switchboard-2.0')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
 shared_module(
     meson.project_name(),
@@ -41,5 +42,5 @@ shared_module(
         switchboard_dep
     ],
     install: true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'network')
+    install_dir : join_paths(switchboard_plugsdir, 'network')
 )


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this switchboard_dep.get_pkgconfig_variable will return a
path from within switchboard's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.