### PR TITLE
Fix row activation and deselect

### DIFF
--- a/src/Views/VPNPage.vala
+++ b/src/Views/VPNPage.vala
@@ -112,7 +112,6 @@ public class Network.VPNPage : Network.Widgets.Page {
             } else {
                 connect_vpn_cb ((VPNMenuItem) row);
             }
-
         });
 
         vpn_list.row_selected.connect (row => {

--- a/src/Widgets/VPN/VPNMenuItem.vala
+++ b/src/Widgets/VPN/VPNMenuItem.vala
@@ -16,8 +16,6 @@
  */
 
 public class Network.VPNMenuItem : Gtk.ListBoxRow {
-    public signal void activate_vpn ();
-    public signal void deactivate_vpn ();
     public NM.RemoteConnection? connection { get; construct; }
 
     public Network.State state { get; set; default = Network.State.DISCONNECTED; }
@@ -91,11 +89,7 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
         update ();
 
         connect_button.clicked.connect (() => {
-            if (state == State.CONNECTED_VPN) {
-                deactivate_vpn ();
-            } else {
-                activate_vpn ();
-            }
+            activate ();
         });
 
         vpn_info_button.clicked.connect (() => {
@@ -142,5 +136,4 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
         state_label.label = GLib.Markup.printf_escaped ("<span font_size='small'>%s</span>", state.to_string ());
         vpn_info_dialog.secondary_text = state.to_string ();
     }
-
 }


### PR DESCRIPTION
This branch addresses a couple issues:

1. When removing the last row, the sensitivity of the "-" button wasn't being updated. Instead of hide/show we do a remove/add to make sure that it is

2. You can now activate rows with a keyboard "enter" or by double clicking the row in addition to pressing the connect/disconnect button

3. The edit connection button works even without a selection so we just remove the sensitivity handling