### PR TITLE
WifiMenuItem: Remove menuitem class

### DIFF
--- a/src/Widgets/WifiMenuItem.vala
+++ b/src/Widgets/WifiMenuItem.vala
@@ -70,8 +70,7 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
         var main_grid = new Gtk.Grid ();
         main_grid.valign = Gtk.Align.CENTER;
         main_grid.column_spacing = 6;
-        main_grid.margin_start = 6;
-        main_grid.margin_end = 6;
+        main_grid.margin = 6;
         main_grid.add (radio_button);
         main_grid.add (spinner);
         main_grid.add (error_img);
@@ -83,7 +82,6 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
         /* Adding the access point triggers update */
         add_ap (ap);
 
-        get_style_context ().add_class ("menuitem");
         add (main_grid);
 
         bind_property ("active", radio_button, "active", GLib.BindingFlags.SYNC_CREATE | GLib.BindingFlags.BIDIRECTIONAL);


### PR DESCRIPTION
I guess this comes from when we were trying to use the same widgets for the indicator as the plug