### PR TITLE
Use ubuntu-system-service to set systemwide proxies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y libgranite-dev libnm-dev libnma-dev libswitchboard-2.0-dev libpolkit-gobject-1-dev meson valac
+        apt install -y libgranite-dev libnm-dev libnma-dev libswitchboard-2.0-dev libpolkit-gobject-1-dev policykit-1 meson valac
     - name: Build
       env:
         DESTDIR: out

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,16 +6,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     container:
       image: elementary/docker:unstable
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y libgranite-dev libnm-dev libnma-dev libswitchboard-2.0-dev meson valac
+        apt install -y libgranite-dev libnm-dev libnma-dev libswitchboard-2.0-dev libpolkit-gobject-1-dev meson valac
     - name: Build
       env:
         DESTDIR: out
@@ -27,10 +27,10 @@ jobs:
   lint:
 
     runs-on: ubuntu-latest
-    
+
     container:
       image: valalang/lint
-      
+
     steps:
     - uses: actions/checkout@v1
     - name: Lint

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You'll need the following dependencies:
 * libnm-dev
 * libnma-dev
 * libswitchboard-2.0-dev
+* policykit-1 (only required for systemwide proxy feature on Ubuntu based distros, see below)
 * libpolkit-gobject-1-dev (only required for systemwide proxy feature on Ubuntu based distros, see below)
 * meson
 * valac

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You'll need the following dependencies:
 * libnm-dev
 * libnma-dev
 * libswitchboard-2.0-dev
+* libpolkit-gobject-1-dev (only required for systemwide proxy feature on Ubuntu based distros, see below)
 * meson
 * valac
 
@@ -24,3 +25,7 @@ Run `meson` to configure the build environment and then `ninja` to build
 To install, use `ninja install`
 
     sudo ninja install
+
+If you are building on something other than an Ubuntu based distribution, use the following instead to disable the systemwide proxy feature which depends on `ubuntu-system-service`:
+
+    meson build --prefix=/usr -Duse_ubuntu_system_service=false

--- a/data/io.elementary.switchboard.network.policy.in
+++ b/data/io.elementary.switchboard.network.policy.in
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <vendor>elementary</vendor>
+  <vendor_url>https://elementary.io/</vendor_url>
+
+  <action id="io.elementary.switchboard.network.setproxy">
+    <description>Set system-wide proxy</description>
+    <message>Authentication is required to change system-wide proxy settings</message>
+    <icon_name>system-users</icon_name>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.imply">com.ubuntu.systemservice.setproxy com.ubuntu.systemservice.setnoproxy</annotate>
+  </action>
+
+</policyconfig>
+

--- a/data/meson.build
+++ b/data/meson.build
@@ -5,3 +5,13 @@ i18n.merge_file(
     install_dir: join_paths(datadir, 'metainfo'),
     install: true
 )
+
+if get_option('use_ubuntu_system_service')
+    i18n.merge_file(
+        input: 'io.elementary.switchboard.network.policy.in',
+        output: 'io.elementary.switchboard.network.policy',
+        po_dir: join_paths(meson.source_root (), 'po', 'extra'),
+        install_dir: join_paths(datadir, 'polkit-1', 'actions'),
+        install: true
+    )
+endif

--- a/meson.build
+++ b/meson.build
@@ -22,6 +22,13 @@ add_project_arguments(
     language: 'vala'
 )
 
+if get_option('use_ubuntu_system_service')
+    add_project_arguments(
+        '--define=USE_UBUNTU_SYSTEM_SERVICE',
+        language: 'vala'
+    )
+endif
+
 subdir('data')
 subdir('src')
 subdir('po')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('use_ubuntu_system_service', type : 'boolean', value : true)

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,1 +1,2 @@
 data/io.elementary.switchboard.network.appdata.xml.in
+data/io.elementary.switchboard.network.policy.in

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -25,6 +25,10 @@ namespace Network {
         private MainView? main_view = null;
 
         public static GLib.Settings proxy_settings;
+        public static GLib.Settings ftp_settings;
+        public static GLib.Settings http_settings;
+        public static GLib.Settings https_settings;
+        public static GLib.Settings socks_settings;
 
         public Plug () {
             var settings = new Gee.TreeMap<string, string?> (null, null);
@@ -39,6 +43,10 @@ namespace Network {
 
         static construct {
             proxy_settings = new GLib.Settings ("org.gnome.system.proxy");
+            ftp_settings = new GLib.Settings ("org.gnome.system.proxy.ftp");
+            http_settings = new GLib.Settings ("org.gnome.system.proxy.http");
+            https_settings = new GLib.Settings ("org.gnome.system.proxy.https");
+            socks_settings = new GLib.Settings ("org.gnome.system.proxy.socks");
         }
 
         public override Gtk.Widget get_widget () {

--- a/src/UbuntuSystemService.vala
+++ b/src/UbuntuSystemService.vala
@@ -26,4 +26,3 @@ public interface UbuntuSystemService : Object {
     [DBus (name = "set_no_proxy")]
     public abstract bool set_no_proxy (string new_no_proxy) throws GLib.Error;
 }
-

--- a/src/UbuntuSystemService.vala
+++ b/src/UbuntuSystemService.vala
@@ -1,0 +1,29 @@
+/*-
+ * Copyright 2019 elementary, Inc. (https://elementary.io)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: David Hewitt <davidmhewitt@gmail.com>
+ */
+
+[DBus (name = "com.ubuntu.SystemService")]
+public interface UbuntuSystemService : Object {
+    [DBus (name = "get_proxy")]
+    public abstract string get_proxy (string proxy_type) throws GLib.Error;
+    [DBus (name = "set_proxy")]
+    public abstract bool set_proxy (string proxy_type, string new_proxy) throws GLib.Error;
+    [DBus (name = "set_no_proxy")]
+    public abstract bool set_no_proxy (string new_no_proxy) throws GLib.Error;
+}
+

--- a/src/Views/ProxyPage.vala
+++ b/src/Views/ProxyPage.vala
@@ -57,6 +57,7 @@ namespace Network.Widgets {
 
 #if USE_UBUNTU_SYSTEM_SERVICE
             configuration_page.changed.connect (on_proxy_settings_changed);
+            configuration_page.notify["manual-mode"].connect (on_proxy_settings_changed);
             exceptions_page.changed.connect (on_proxy_settings_changed);
 
             try {
@@ -157,6 +158,8 @@ namespace Network.Widgets {
             if (!status_switch.active) {
                 Network.Plug.proxy_settings.set_string ("mode", "none");
             }
+
+            on_proxy_settings_changed ();
         }
 
         protected override void update_switch () {

--- a/src/Widgets/Proxy/ProxyExceptionsPage.vala
+++ b/src/Widgets/Proxy/ProxyExceptionsPage.vala
@@ -18,7 +18,9 @@
  */
 
 namespace Network.Widgets {
-    public class ExecepionsPage : Gtk.Box {
+    public class ProxyExceptionsPage : Gtk.Box {
+        public signal void changed ();
+
         private Gtk.ListBox ignored_list;
         private Gtk.ListBoxRow[] items = {};
 
@@ -91,6 +93,8 @@ namespace Network.Widgets {
             Network.Plug.proxy_settings.set_strv ("ignore-hosts", new_hosts);
             entry.text = "";
             update_list ();
+
+            changed ();
         }
 
         private void list_exceptions () {
@@ -126,6 +130,8 @@ namespace Network.Widgets {
 
             Network.Plug.proxy_settings.set_strv ("ignore-hosts", new_hosts);
             update_list ();
+
+            changed ();
         }
 
         private void update_list () {

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,19 +26,30 @@ plug_files = files(
 switchboard_dep = dependency('switchboard-2.0')
 switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
+deps = [
+    dependency('glib-2.0'),
+    dependency('gobject-2.0'),
+    dependency('granite', version: '>=5.2.3'),
+    dependency('gtk+-3.0'),
+    dependency('libnm'),
+    dependency('libnma'),
+    meson.get_compiler('vala').find_library('posix'),
+    switchboard_dep
+]
+
+if get_option('use_ubuntu_system_service')
+    desktop_enums = meson.get_compiler('vala').find_library('gdesktopenums-3.0')
+    deps += dependency('polkit-gobject-1')
+    deps += desktop_enums
+    plug_files += files (
+        'UbuntuSystemService.vala'
+    )
+endif
+
 shared_module(
     meson.project_name(),
     plug_files,
-    dependencies: [
-        dependency('glib-2.0'),
-        dependency('gobject-2.0'),
-        dependency('granite', version: '>=5.2.3'),
-        dependency('gtk+-3.0'),
-        dependency('libnm'),
-        dependency('libnma'),
-        meson.get_compiler('vala').find_library('posix'),
-        switchboard_dep
-    ],
+    dependencies: deps,
     install: true,
     install_dir : join_paths(switchboard_plugsdir, 'network')
 )


### PR DESCRIPTION
Supersedes #95 

Fixes #37 

This is required to get Sideload and the Flatpak part of AppCenter working behind a proxy without users having to edit config files and environment variables by hand. It also makes the necessary config changes so that the `apt` CLI and others like `curl` work.

Adds a new meson option to disable the function as it has a runtime dependency on `ubuntu-system-service` and requires polkit as an extra dep.