### PR TITLE
Better Wifi encryption type handling

### DIFF
--- a/src/Widgets/WifiMenuItem.vala
+++ b/src/Widgets/WifiMenuItem.vala
@@ -126,7 +126,7 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
         img_strength.icon_name = "network-wireless-signal-" + strength_to_string (strength);
         img_strength.show_all ();
 
-        var flags = ap.get_wpa_flags ();
+        var flags = ap.get_wpa_flags () | ap.get_rsn_flags ();
         is_secured = false;
         if (NM.@80211ApSecurityFlags.GROUP_WEP40 in flags) {
             is_secured = true;
@@ -137,7 +137,7 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
         } else if (NM.@80211ApSecurityFlags.KEY_MGMT_PSK in flags) {
             is_secured = true;
             state_string = _("WPA encrypted");
-        } else if (flags != NM.@80211ApSecurityFlags.NONE || ap.get_rsn_flags () != NM.@80211ApSecurityFlags.NONE) {
+        } else if (flags != NM.@80211ApSecurityFlags.NONE) {
             is_secured = true;
             state_string = _("Encrypted");
         } else {


### PR DESCRIPTION
We were hardcoding a `wpa-psk` key management type, which I suspect means Switchboard wasn't able to connect to anything other than WPA[2] networks. This doesn't seem to be necessary as the auth dialog still prompts for the correct type of Wifi credentials without this.

I've added some code that in theory supports WPA-Enterprise APs that use certificates and/or usernames and passwords for auth. This is based off code in GNOME's nm-applet.

I've also updated that code that decides what string to display under each network to check `rsn_flags` as well as `wpa_flags` for the encryption type as it was just showing every network as "Encrypted" for me. Now I get the proper "WEP/WPA" disambiguation.

This will need testing to check Switchboard can still add/connect a variety of Wifi networks. I can only realistically test WPA networks, as my router doesn't let me configure WEP, unsurprisingly :rofl: 

Also worth noting that I've only tested this on focal, no testing has been performed on bionic.