### PR TITLE
Release 2.3.3

### DIFF
--- a/data/io.elementary.switchboard.network.appdata.xml.in
+++ b/data/io.elementary.switchboard.network.appdata.xml.in
@@ -7,6 +7,15 @@
   <icon type="stock">preferences-system-network</icon>
   <translation type="gettext">networking-plug</translation>
   <releases>
+    <release version="2.3.3" date="2020-10-08" urgency="medium">
+      <description>
+        <p>Minor updates</p>
+        <ul>
+          <li>Better status when wireless network is disabled</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="2.3.2" date="2020-09-02" urgency="medium">
       <description>
         <p>Minor updates</p>

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'networking',
     'vala', 'c',
-    version: '2.3.2'
+    version: '2.3.3'
 )
 
 gettext_name = meson.project_name() + '-plug'


### PR DESCRIPTION
It's been a while, we're still compatible with 5.x, and we have a nice little fix.

https://github.com/elementary/switchboard-plug-network/compare/2.3.2...release-2.3.3