### PR TITLE
Fix plug crashes

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -197,7 +197,6 @@ public class Network.MainView : Gtk.Paned {
 
         update_interfaces_names ();
         update_all ();
-        show_all ();
     }
 
     private void update_all () {
@@ -221,7 +220,6 @@ public class Network.MainView : Gtk.Paned {
         device_list.add_iface_to_list (widget_interface);
 
         update_networking_state ();
-        show_all ();
     }
 
     private void remove_interface (Widgets.Page widget_interface) {
@@ -240,8 +238,6 @@ public class Network.MainView : Gtk.Paned {
         }
 
         widget_interface.destroy ();
-
-        show_all ();
     }
 
     private void add_connection (NM.RemoteConnection connection) {

--- a/src/Widgets/DeviceList.vala
+++ b/src/Widgets/DeviceList.vala
@@ -71,7 +71,6 @@ namespace Network.Widgets {
             }
 
             add (item);
-            show_all ();
         }
 
         public void remove_iface_from_list (Widgets.Page iface) {

--- a/src/Widgets/Page.vala
+++ b/src/Widgets/Page.vala
@@ -94,7 +94,7 @@ namespace Network.Widgets {
             } else if (status_switch.active && device.get_state () == NM.DeviceState.DISCONNECTED) {
                 var connection = NM.SimpleConnection.new ();
                 var remote_array = device.get_available_connections ();
-                if (remote_array != null) {
+                if (remote_array != null && remote_array.length > 0) {
                     connection.set_path (remote_array.get (0).get_path ());
                     unowned NetworkManager network_manager = NetworkManager.get_default ();
                     network_manager.client.activate_connection_async.begin (connection, device, null, null, null);


### PR DESCRIPTION
Fixes #311

Two parts to this, the first commit fixes a crash that happens while the plug is open and you attach a new NIC that doesn't have any available connections.

The second fixes plug crashes on startup with an extra NIC plugged in. 

The backtrace for the second type of crash is just a load of GTK signal emissions about showing/mapping/realizing widgets, and I couldn't track it down to anything specific in the networking plug. But removing a bunch of these `show_all` calls from every single method ever where they're really not necessary seems to fix things.