### PR TITLE
fix manual network (ethernet) interface shutdown

### DIFF
--- a/src/Views/EthernetPage.vala
+++ b/src/Views/EthernetPage.vala
@@ -82,11 +82,9 @@ namespace Network.Widgets {
 
             if (state == NM.DeviceState.UNAVAILABLE) {
                 widgets_stack.visible_child = no_cable;
-                status_switch.active = false;
                 status_switch.sensitive = false;
             } else {
                 widgets_stack.visible_child = top_revealer;
-                status_switch.active = true;
                 status_switch.sensitive = true;
             }
         }


### PR DESCRIPTION
You cannot change the state of the switch when the cable is disconnected. This leads to the inability to disable the network interface manually, since it requires disconnecting both the interface and the cable