### PR TITLE
Add support for libnm 1.43

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -25,14 +25,14 @@ namespace Network {
 
         public static void update_secrets (NM.RemoteConnection connection, UpdateSecretCallback callback) {
 #if HAS_NM_1_43
-            connection.get_secrets_async.begin (NM.SettingWireless.SETTING_NAME, null, (obj, res) => {
+            connection.get_secrets_async.begin (NM.SettingWirelessSecurity.SETTING_NAME, null, (obj, res) => {
 #else
             connection.get_secrets_async.begin (NM.SettingWireless.SECURITY_SETTING_NAME, null, (obj, res) => {
 #endif
                 try {
                     var secrets = connection.get_secrets_async.end (res);
 #if HAS_NM_1_43
-                    connection.update_secrets (NM.SettingWireless.SETTING_NAME, secrets);
+                    connection.update_secrets (NM.SettingWirelessSecurity.SETTING_NAME, secrets);
 #else
                     connection.update_secrets (NM.SettingWireless.SECURITY_SETTING_NAME, secrets);
 #endif

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -24,10 +24,18 @@ namespace Network {
         public delegate void UpdateSecretCallback ();
 
         public static void update_secrets (NM.RemoteConnection connection, UpdateSecretCallback callback) {
+#if HAS_NM_1_43
+            connection.get_secrets_async.begin (NM.SettingWireless.SETTING_NAME, null, (obj, res) => {
+#else
             connection.get_secrets_async.begin (NM.SettingWireless.SECURITY_SETTING_NAME, null, (obj, res) => {
+#endif
                 try {
                     var secrets = connection.get_secrets_async.end (res);
+#if HAS_NM_1_43
+                    connection.update_secrets (NM.SettingWireless.SETTING_NAME, secrets);
+#else
                     connection.update_secrets (NM.SettingWireless.SECURITY_SETTING_NAME, secrets);
+#endif
                 } catch (Error e) {
                     warning ("%s\n", e.message);
                     return;

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,6 +26,13 @@ plug_files = files(
 switchboard_dep = dependency('switchboard-2.0')
 switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
+libnm_dep = dependency('libnm', version: '>=1.20.6')
+
+args = []
+if libnm_dep.version().version_compare('>=1.43.0')
+    args += '--define=HAS_NM_1_43'
+endif
+
 shared_module(
     meson.project_name(),
     plug_files,
@@ -35,11 +42,12 @@ shared_module(
         dependency('gobject-2.0'),
         dependency('granite', version: '>=5.2.3'),
         dependency('gtk+-3.0'),
-        dependency('libnm', version: '>=1.20.6'),
+        libnm_dep,
         dependency('libnma'),
         meson.get_compiler('vala').find_library('posix'),
         switchboard_dep
     ],
+    vala_args: args,
     install: true,
     install_dir : join_paths(switchboard_plugsdir, 'network')
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,7 +29,7 @@ switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define
 libnm_dep = dependency('libnm', version: '>=1.20.6')
 
 args = []
-if libnm_dep.version().version_compare('>=1.43.0')
+if libnm_dep.version().version_compare('>=1.43.3')
     args += '--define=HAS_NM_1_43'
 endif
 


### PR DESCRIPTION
Below are the versions of libnm that Fedora uses:

- Fedora 37: 1.40.10-1
- Fedora 38: 1.42.6-1
- Fedora Rawhide: 1.43.6-1

This project could not be compiled on Fedora Rawhide.

[Before](https://github.com/meisenzahl/distro-agnostic/actions/runs/4782702651/jobs/8502288593#step:5:3609)

[After](https://github.com/meisenzahl/distro-agnostic/actions/runs/4782964418/jobs/8502760488)

@tintou I'm not sure if we need to fix the problem or if it's a bug in the bindings for Vala. What do you think?