### PR TITLE
Update "Airplane Mode" switch margin

### DIFF
--- a/src/Widgets/Footer.vala
+++ b/src/Widgets/Footer.vala
@@ -24,14 +24,16 @@ namespace Network {
             get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
 
             var label = new Gtk.Label (_("Airplane Mode")) {
-                margin_start = 6
+                margin_start = 3
             };
             label.get_style_context ().add_class (Granite.STYLE_CLASS_H4_LABEL);
 
 
             var airplane_switch = new Gtk.Switch () {
-                margin = 12,
-                margin_end = 6
+                margin_start = 6,
+                margin_top = 6,
+                margin_bottom = 6,
+                margin_end = 3
             };
 
             this.pack_start (label);


### PR DESCRIPTION
Updated margin of the footer switch to match other plugs.

### Before
![image](https://user-images.githubusercontent.com/80143868/236419133-f572a664-6326-4f66-9b9d-388d7bb61e44.png)

---
### After
![image](https://user-images.githubusercontent.com/80143868/236418957-83c0bc14-9bc1-4f7d-8bd1-2335b0e2b309.png)
