### PR TITLE
Avoid compilation warnings about deprecated call

### DIFF
--- a/src/NetworkManager.vala
+++ b/src/NetworkManager.vala
@@ -109,11 +109,17 @@ public class Network.NetworkManager : GLib.Object {
 
     public async void deactivate_hotspot (NM.DeviceWifi wifi_device) {
         unowned NM.ActiveConnection active_connection = wifi_device.get_active_connection ();
-        try {
-            client.deactivate_connection (active_connection);
-        } catch (Error e) {
-            critical (e.message);
-        }
+        client.deactivate_connection_async.begin (
+            active_connection,
+            null,
+            (obj, res) => {
+                try {
+                    client.deactivate_connection_async.end (res);
+                } catch (Error e) {
+                    critical (e.message);
+                }
+            }
+        );
     }
 
     private static void set_wpa_key (NM.SettingWirelessSecurity setting, string key) {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -81,12 +81,10 @@ namespace Network {
             return true;
         }
 
-        public enum CustomMode {
+        public enum ProxyMode {
             PROXY_NONE = 0,
             PROXY_MANUAL,
             PROXY_AUTO,
-            HOTSPOT_ENABLED,
-            HOTSPOT_DISABLED,
             INVALID
         }
 

--- a/src/Views/ProxyPage.vala
+++ b/src/Views/ProxyPage.vala
@@ -80,22 +80,22 @@ namespace Network.Widgets {
         }
 
         private void update_mode () {
-            var mode = Utils.CustomMode.INVALID;
+            var mode = Utils.ProxyMode.INVALID;
             switch (Network.Plug.proxy_settings.get_string ("mode")) {
                 case "none":
-                    mode = Utils.CustomMode.PROXY_NONE;
+                    mode = Utils.ProxyMode.PROXY_NONE;
                     status_switch.active = false;
                     break;
                 case "manual":
-                    mode = Utils.CustomMode.PROXY_MANUAL;
+                    mode = Utils.ProxyMode.PROXY_MANUAL;
                     status_switch.active = true;
                     break;
                 case "auto":
-                    mode = Utils.CustomMode.PROXY_AUTO;
+                    mode = Utils.ProxyMode.PROXY_AUTO;
                     status_switch.active = true;
                     break;
                 default:
-                    mode = Utils.CustomMode.INVALID;
+                    mode = Utils.ProxyMode.INVALID;
                     break;
             }
 

--- a/src/Views/WifiPage.vala
+++ b/src/Views/WifiPage.vala
@@ -383,11 +383,16 @@ public class Network.WifiInterface : Network.Widgets.Page {
             };
             disconnect_btn.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
             disconnect_btn.clicked.connect (() => {
-                try {
-                    device.disconnect (null);
-                } catch (Error e) {
-                    warning (e.message);
-                }
+                device.disconnect_async.begin (
+                    null,
+                    (obj, res) => {
+                        try {
+                            device.disconnect_async.end (res);
+                        } catch (Error e) {
+                            warning (e.message);
+                        }
+                    }
+                );
             });
 
             settings_btn = new Network.Widgets.SettingsButton.from_device (wifi_device, _("Settings…")) {
@@ -435,7 +440,10 @@ public class Network.WifiInterface : Network.Widgets.Page {
         if (active == software_locked) {
             rfkill.set_software_lock (RFKillDeviceType.WLAN, !active);
             unowned NetworkManager network_manager = NetworkManager.get_default ();
-            network_manager.client.wireless_set_enabled (active);
+            network_manager.client.dbus_set_property.begin (
+                NM.DBUS_PATH, NM.DBUS_INTERFACE, "WirelessEnabled",
+                active, -1, null
+            );
         }
     }
 

--- a/src/Widgets/DeviceItem.vala
+++ b/src/Widgets/DeviceItem.vala
@@ -46,9 +46,9 @@ namespace Network.Widgets {
             page.bind_property ("title", this, "title", SYNC_CREATE);
             page.bind_property ("icon-name", this, "icon-name", SYNC_CREATE);
 
-            switch_status (Utils.CustomMode.INVALID, page.state);
+            switch_status (Utils.ProxyMode.INVALID, page.state);
             page.notify["state"].connect (() => {
-                switch_status (Utils.CustomMode.INVALID, page.state);
+                switch_status (Utils.ProxyMode.INVALID, page.state);
             });
         }
 
@@ -100,7 +100,7 @@ namespace Network.Widgets {
             bind_property ("icon-name", row_image, "icon-name");
         }
 
-        public void switch_status (Utils.CustomMode custom_mode, NM.DeviceState? state = null) {
+        public void switch_status (Utils.ProxyMode custom_mode, NM.DeviceState? state = null) {
             if (state != null) {
                 switch (state) {
                     case NM.DeviceState.ACTIVATED:
@@ -122,24 +122,25 @@ namespace Network.Widgets {
                 } else {
                     subtitle = Utils.state_to_string (state);
                 }
-            } else if (custom_mode != Utils.CustomMode.INVALID) {
+            } else {
                 switch (custom_mode) {
-                    case Utils.CustomMode.PROXY_NONE:
+                    case Utils.ProxyMode.PROXY_NONE:
                         subtitle = _("Disabled");
                         status_image.icon_name = "user-offline";
                         break;
-                    case Utils.CustomMode.PROXY_MANUAL:
+                    case Utils.ProxyMode.PROXY_MANUAL:
                         subtitle = _("Enabled (manual mode)");
                         status_image.icon_name = "user-available";
                         break;
-                    case Utils.CustomMode.PROXY_AUTO:
+                    case Utils.ProxyMode.PROXY_AUTO:
                         subtitle = _("Enabled (auto mode)");
                         status_image.icon_name = "user-available";
                         break;
-                    default:
-                        // do nothing
-                        return;
-               }
+                    case Utils.ProxyMode.INVALID:
+                        subtitle = _("Disabled (error)");
+                        status_image.icon_name = "user-busy";
+                        break;
+                }
             }
 
            subtitle = "<span font_size='small'>" + subtitle + "</span>";

--- a/src/Widgets/DeviceItem.vala
+++ b/src/Widgets/DeviceItem.vala
@@ -136,6 +136,9 @@ namespace Network.Widgets {
                         subtitle = _("Enabled (auto mode)");
                         status_image.icon_name = "user-available";
                         break;
+                    default:
+                        // do nothing
+                        return;
                }
             }
 

--- a/src/Widgets/Page.vala
+++ b/src/Widgets/Page.vala
@@ -108,24 +108,29 @@ namespace Network.Widgets {
             }
 
             if (!status_switch.active && device.get_state () == NM.DeviceState.ACTIVATED) {
-                try {
-                    device.disconnect (null);
-                } catch (Error e) {
-                    status_switch.active = true;
+                device.disconnect_async.begin (
+                    null,
+                    (obj, res) => {
+                        try {
+                            device.disconnect_async.end (res);
+                        } catch (Error e) {
+                            status_switch.active = true;
 
-                    var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                        _("Failed To Disconnect"),
-                        _("Unable to disconnect from the currently connected network"),
-                        "network-error",
-                        Gtk.ButtonsType.CLOSE
-                    ) {
-                        modal = true,
-                        transient_for = (Gtk.Window) get_root ()
-                    };
-                    message_dialog.show_error_details (e.message);
-                    message_dialog.present ();
-                    message_dialog.response.connect (message_dialog.destroy);
-                }
+                            var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                                _("Failed To Disconnect"),
+                                _("Unable to disconnect from the currently connected network"),
+                                "network-error",
+                                Gtk.ButtonsType.CLOSE
+                            ) {
+                                modal = true,
+                                transient_for = (Gtk.Window) get_root ()
+                            };
+                            message_dialog.show_error_details (e.message);
+                            message_dialog.present ();
+                            message_dialog.response.connect (message_dialog.destroy);
+                        }
+                    }
+                );
             } else if (status_switch.active && device.get_state () == NM.DeviceState.DISCONNECTED) {
                 var connection = NM.SimpleConnection.new ();
                 var remote_array = device.get_available_connections ();

--- a/src/Widgets/WifiMenuItem.vala
+++ b/src/Widgets/WifiMenuItem.vala
@@ -173,6 +173,14 @@ public class Network.WifiMenuItem : Gtk.ListBoxRow {
             case NM.DeviceState.ACTIVATED:
                 connect_button_revealer.reveal_child = false;
                 break;
+            default:
+                /* Could be a lot of various status (for now, one of:
+                 * `DISCONNECTED', `IP_CHECK', `CONFIG', `UNKNOWN',
+                 * `UNAVAILABLE', `IP_CONFIG', `SECONDARIES', `UNMANAGED',
+                 * `NEED_AUTH', `DEACTIVATING'). Showing the spinner might let
+                 * end-user try to have a look to what is going on. */
+                spinner.active = true;
+                break;
         }
 
         status_label.label = GLib.Markup.printf_escaped ("<span font_size='small'>%s</span>", state_string);


### PR DESCRIPTION
As of NetworkManager 1.22, a lot of function should be asynchronously called.

This MR remove all the compilation warning still visible (at least on Archlinux). Maybe it’s only preparatory stuff for Debian/Ubuntu distros.