### PR TITLE
VPNMenuItem: fix empty info dialog

### DIFF
--- a/src/Widgets/VPN/VPNMenuItem.vala
+++ b/src/Widgets/VPN/VPNMenuItem.vala
@@ -26,7 +26,6 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
     private Gtk.Image vpn_state;
     private Gtk.Label state_label;
     private Gtk.Label vpn_label;
-    private Widgets.VPNInfoDialog vpn_info_dialog;
 
     public VPNMenuItem (NM.RemoteConnection _connection) {
         Object (
@@ -59,10 +58,6 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
             ellipsize = Pango.EllipsizeMode.END,
             hexpand = true,
             xalign = 0
-        };
-
-        vpn_info_dialog = new Widgets.VPNInfoDialog (connection) {
-            modal = true
         };
 
         var vpn_info_button = new Gtk.Button () {
@@ -99,7 +94,12 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
         connect_button.clicked.connect (() => activate ());
 
         vpn_info_button.clicked.connect (() => {
-            vpn_info_dialog.transient_for = (Gtk.Window) get_toplevel ();
+            var vpn_info_dialog = new Widgets.VPNInfoDialog (connection) {
+                modal = true,
+                secondary_text = Utils.state_to_string (state),
+                transient_for = (Gtk.Window) get_toplevel ()
+            };
+
             vpn_info_dialog.present ();
             vpn_info_dialog.response.connect (vpn_info_dialog.destroy);
         });
@@ -140,7 +140,6 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
         }
 
         state_label.label = GLib.Markup.printf_escaped ("<span font_size='small'>%s</span>", Utils.state_to_string (state));
-        vpn_info_dialog.secondary_text = Utils.state_to_string (state);
     }
 
 }


### PR DESCRIPTION
Fixes a bug where closing and reopening the dialog gives you a blank window