### PR TITLE
VPNMenuItem: use emblem status icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 You'll need the following dependencies:
 
-* libgranite-7-dev
+* libgranite-7-dev >= 7.4.0
 * libnm-dev
 * libnma-gtk4-dev
 * libswitchboard-3-dev

--- a/src/Widgets/VPN/VPNMenuItem.vala
+++ b/src/Widgets/VPN/VPNMenuItem.vala
@@ -43,7 +43,7 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
             icon_size = LARGE
         };
 
-        vpn_state = new Gtk.Image.from_icon_name ("user-offline") {
+        vpn_state = new Gtk.Image.from_icon_name ("emblem-disabled") {
             halign = Gtk.Align.END,
             valign = Gtk.Align.END
         };
@@ -137,24 +137,24 @@ public class Network.VPNMenuItem : Gtk.ListBoxRow {
 
         switch (state) {
             case NM.DeviceState.FAILED:
-                vpn_state.icon_name = "user-busy";
+                vpn_state.icon_name = "emblem-error";
                 connect_button.label = _("Connect");
                 connect_button.sensitive = true;
                 connect_button.remove_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
                 break;
             case NM.DeviceState.PREPARE:
-                vpn_state.icon_name = "user-away";
+                vpn_state.icon_name = "emblem-mixed";
                 connect_button.sensitive = false;
                 connect_button.remove_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
                 break;
             case NM.DeviceState.ACTIVATED:
-                vpn_state.icon_name = "user-available";
+                vpn_state.icon_name = "emblem-enabled";
                 connect_button.label = _("Disconnect");
                 connect_button.sensitive = true;
                 connect_button.add_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);
                 break;
             case NM.DeviceState.DISCONNECTED:
-                vpn_state.icon_name = "user-offline";
+                vpn_state.icon_name = "emblem-disabled";
                 connect_button.label = _("Connect");
                 connect_button.sensitive = true;
                 connect_button.remove_css_class (Granite.STYLE_CLASS_DESTRUCTIVE_ACTION);

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,7 +37,7 @@ shared_module(
     dependencies: [
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
-        dependency('granite-7'),
+        dependency('granite-7', version: '>=7.4.0'),
         dependency('gtk4'),
         dependency('libadwaita-1', version: '>=1.4'),
         libnm_dep,


### PR DESCRIPTION
Fixes chat bubble status icons. These emblems are now resourced into Granite