### PR TITLE
Auto select active network

### DIFF
--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -215,6 +215,8 @@ public class Network.MainView : Gtk.Box {
             return;
         }
 
+        device.state_changed.connect_after (update_networking_state);
+
         Widgets.Page? widget_interface = null;
         Widgets.Page? hotspot_interface = null;
 
@@ -320,6 +322,14 @@ public class Network.MainView : Gtk.Box {
         unowned NetworkManager network_manager = NetworkManager.get_default ();
         if (network_manager.client.networking_get_enabled ()) {
             device_list.sensitive = true;
+            unowned var child = device_list.get_first_child ();
+            while (child != null) {
+                if (child is Widgets.DeviceItem && ((Widgets.DeviceItem) child).page.state == NM.DeviceState.ACTIVATED) {
+                    child.activate ();
+                    return;
+                }
+                child = child.get_next_sibling ();
+            }
             device_list.get_row_at_index (0).activate ();
         } else {
             device_list.sensitive = false;

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -215,8 +215,6 @@ public class Network.MainView : Gtk.Box {
             return;
         }
 
-        device.state_changed.connect_after (update_networking_state);
-
         Widgets.Page? widget_interface = null;
         Widgets.Page? hotspot_interface = null;
 


### PR DESCRIPTION
Automatically select the first device which is in the activated state.

I typically use the wifi connection on my laptop which also has ethernet, as would most folks. 

Whenever I open the networking plug, the first device (wired) is pre-selected and I have to do an extra click to select the wifi device to view or make changes.

Now, the wifi gets pre-selected instead, when opening the plug:

![network](https://github.com/user-attachments/assets/5d8bd0c7-0f03-493b-b53c-9e530115ee48)

If both (or neither) wired and (nor) wireless are activated, then the first (wired) is pre-selected, preserving the current (old) behaviour.

Also, while the plug is open, toggling devices (wired, wireless) updates the selected device.
edit: No longer auto switch while plug is already open.