### PR TITLE
RKFill: add airplane mode property

### DIFF
--- a/data/network.metainfo.xml.in
+++ b/data/network.metainfo.xml.in
@@ -28,6 +28,19 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
+    <release version="8.2.0" date="2025-08-12" urgency="medium">
+      <description>
+        <p>Minor updates</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/switchboard-plug-network/issues/346">Airplane mode switch does not change when mode changed with wingpanel</issue>
+        <issue url="https://github.com/elementary/switchboard-plug-network/issues/360">Airplane mode seems to disable wired network, too</issue>
+      </issues>
+    </release>
+
     <release version="8.1.0" date="2025-02-12" urgency="medium">
       <description>
         <p>Minor updates</p>

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -27,6 +27,7 @@ public class Network.MainView : Gtk.Box {
     private Gtk.ListBox device_list;
     private Gtk.Stack content;
     private NM.Device current_device = null;
+    private RFKillManager rfkill;
     private VPNPage vpn_page;
 
     construct {
@@ -61,28 +62,17 @@ public class Network.MainView : Gtk.Box {
         device_list.append (proxy);
         device_list.append (vpn);
 
-        var label = new Gtk.Label (_("Airplane Mode"));
-
-        var airplane_switch = new Gtk.Switch () {
+        var airplane_switch = new Granite.SwitchModelButton (("Airplane Mode")) {
+            hexpand = true,
             valign = CENTER
         };
 
         var footer = new Gtk.ActionBar ();
-        footer.pack_start (label);
-        footer.pack_end (airplane_switch);
-
-        var airplane_mode = new Granite.Placeholder (
-            _("Airplane Mode Is Enabled")) {
-            description = _("While in Airplane Mode your device's Internet access and any wireless and ethernet connections, will be suspended.\n\n") +
-            _("You will be unable to browse the web or use applications that require a network connection or Internet access.\n") +
-            _("Applications and other functions that do not require the Internet will be unaffected."),
-            icon = new ThemedIcon ("airplane-mode")
-        };
+        footer.pack_start (airplane_switch);
 
         content = new Gtk.Stack () {
             hexpand = true
         };
-        content.add_named (airplane_mode, "airplane-mode-info");
         content.add_child (vpn_page);
         content.add_child (proxy.page);
 
@@ -141,24 +131,9 @@ public class Network.MainView : Gtk.Box {
         update_networking_state ();
         nm_client.notify["networking-enabled"].connect (update_networking_state);
 
-        airplane_switch.notify["active"].connect (() => {
-            nm_client.dbus_call.begin (
-                NM.DBUS_PATH, NM.DBUS_INTERFACE, "Enable",
-                new GLib.Variant.tuple ({!airplane_switch.active}),
-                null, -1, null,
-                (obj, res) => {
-                    try {
-                        nm_client.dbus_call.end (res);
-                    } catch (Error e) {
-                        warning (e.message);
-                    }
-                }
-            );
-        });
-
-        if (!airplane_switch.active && !nm_client.networking_enabled) {
-            airplane_switch.activate ();
-        }
+        rfkill = new RFKillManager ();
+        rfkill.open ();
+        rfkill.bind_property ("airplane-mode", airplane_switch, "active", BIDIRECTIONAL | SYNC_CREATE);
     }
 
     private void device_removed_cb (NM.Device device) {
@@ -339,7 +314,6 @@ public class Network.MainView : Gtk.Box {
             device_list.sensitive = false;
             current_device = null;
             device_list.select_row (null);
-            content.set_visible_child_name ("airplane-mode-info");
         }
     }
 

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -62,7 +62,7 @@ public class Network.MainView : Gtk.Box {
         device_list.append (proxy);
         device_list.append (vpn);
 
-        var airplane_switch = new Granite.SwitchModelButton (("Airplane Mode")) {
+        var airplane_switch = new Granite.SwitchModelButton (_("Airplane Mode")) {
             hexpand = true,
             valign = CENTER
         };

--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -80,6 +80,60 @@ public class RFKillManager : Object {
         return devices;
     }
 
+    /*
+    * Toggle Airplane Mode
+    *
+    * Modern mobile platforms don't disable Bluetooth, we skip it too
+    *
+    * Setting airplane mode from here does all software lock, whereas setting
+    * from a key press does all hardware lock. We need one of these two things—
+    * all devices to be locked somehow—to consider it Airplane Mode
+    */
+    public bool airplane_mode {
+        get {
+            var all_hardware_locked = true;
+            var all_software_locked = true;
+
+            foreach (unowned var device in get_devices ()) {
+                if (device.device_type == BLUETOOTH) {
+                    continue;
+                }
+
+                if (!device.software_lock) {
+                    all_software_locked = false;
+                }
+
+                if (!device.hardware_lock) {
+                    all_hardware_locked = false;
+                }
+            }
+
+            return all_hardware_locked || all_software_locked;
+        }
+
+        set {
+            set_software_lock (WLAN, value);
+            set_software_lock (UWB, value);
+            set_software_lock (WIMAX, value);
+            set_software_lock (WMAN, value);
+
+            /*
+             * Some hardware keys still turn off bluetooth so we iterate over
+             * devices to check if bluetooth was hardware locked and unlock it
+             * but we don't want to toggle it back on if it was manually disabled
+             * in software
+             */
+            if (!value) {
+                foreach (unowned var device in get_devices ()) {
+                    if (device.device_type == BLUETOOTH && device.hardware_lock) {
+                        set_software_lock (BLUETOOTH, false);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     public void set_software_lock (RFKillDeviceType type, bool lock_enabled) {
         var event = RFKillEvent ();
         event.type = type;
@@ -117,6 +171,7 @@ public class RFKillManager : Object {
                 device._hardware_lock = event.hard != 0;
                 device.changed ();
                 device_changed (device);
+                notify_property ("airplane-mode");
             }
             break;
         }


### PR DESCRIPTION
Fixes #346 
Fixes #360

Adds a proper airplane mode function, the same as in https://github.com/elementary/wingpanel-indicator-network/blob/master/src/rfkill.vala#L83

This turns of cellular and wireless radios, but not bluetooth or ethernet. Remove the "Airplane Mode" placeholder since this no longer blocks all of networking and the description here no longer applies