### PR TITLE
rfkill: Use sizeof instead of literal size

### DIFF
--- a/src/rfkill.vala
+++ b/src/rfkill.vala
@@ -28,7 +28,7 @@ public class RFKillDevice {
             event.idx = idx;
             event.op = RFKillOperation.CHANGE;
             event.soft = value ? 1 : 0;
-            if (Posix.write (manager.fd, &event, 8) != 8)
+            if (Posix.write (manager.fd, &event, sizeof (RFKillEvent)) != sizeof (RFKillEvent))
                 return;
         }
     }
@@ -85,7 +85,7 @@ public class RFKillManager : Object {
         event.type = type;
         event.op = RFKillOperation.CHANGE_ALL;
         event.soft = lock_enabled ? 1 : 0;
-        if (Posix.write (fd, &event, 8) != 8)
+        if (Posix.write (fd, &event, sizeof (RFKillEvent)) != sizeof (RFKillEvent))
             return;
     }
 
@@ -94,7 +94,7 @@ public class RFKillManager : Object {
 
     private bool read_event () {
         var event = RFKillEvent ();
-        if (Posix.read (fd, &event, 8) != 8)
+        if (Posix.read (fd, &event, sizeof (RFKillEvent)) != sizeof (RFKillEvent))
             return false;
 
         switch (event.op) {


### PR DESCRIPTION
Same fix with elementary/wingpanel-indicator-network#349
