### PR TITLE
control: Depend on nm-connection-editor for OS 9

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,9 @@ Homepage: https://github.com/elementary/switchboard-plug-network
 
 Package: io.elementary.settings.network
 Architecture: any
-Depends: network-manager-gnome, ${misc:Depends}, ${shlibs:Depends}
+Depends: nm-connection-editor | network-manager-gnome,
+         ${misc:Depends},
+         ${shlibs:Depends}
 Enhances: io.elementary.settings
 Recommends: network-manager-openvpn-gnome
 Description: Manage network connections


### PR DESCRIPTION
Fixes #452

## Checklists
- [x] The .deb file built from this branch with `debuild -us -uc` can be installed on OS 8 Daily
<details>

```
user@elementary-8-daily:~$ sudo apt install ./io.elementary.settings.network_8.2.0_amd64.deb 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'io.elementary.settings.network' instead of './io.elementary.settings.network_8.2.0_amd64.deb'
The following packages will be DOWNGRADED:
  io.elementary.settings.network
0 upgraded, 0 newly installed, 1 downgraded, 0 to remove and 0 not upgraded.
Need to get 0 B/164 kB of archives.
After this operation, 43.0 kB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 /home/user/io.elementary.settings.network_8.2.0_amd64.deb io.elementary.settings.network amd64 8.2.0 [164 kB]
dpkg: warning: downgrading io.elementary.settings.network from 8.2.0+r1650+pkg859~daily~ubuntu8.1 to 8.2.0
(Reading database ... 159236 files and directories currently installed.)
Preparing to unpack .../io.elementary.settings.network_8.2.0_amd64.deb ...
Unpacking io.elementary.settings.network (8.2.0) over (8.2.0+r1650+pkg859~daily~ubuntu8.1) ...
Setting up io.elementary.settings.network (8.2.0) ...
N: Download is performed unsandboxed as root as file '/home/user/io.elementary.settings.network_8.2.0_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
user@elementary-8-daily:~$
```

</details>

- [x] The .deb file built from this branch with `debuild -us -uc` can be installed on OS 9 Daily
<details>

```
elementary@elementary:~$ sudo apt install ./io.elementary.settings.network_8.2.0_amd64.deb 
Note, selecting 'io.elementary.settings.network' instead of './io.elementary.settings.network_8.2.0_amd64.deb'
The following package was automatically installed and is no longer required:
  dracut-core
Use 'sudo apt autoremove' to remove it.

DOWNGRADING:
  io.elementary.settings.network

Summary:
  Upgrading: 0, Installing: 0, Downgrading: 1, Removing: 0, Not Upgrading: 0
  Download size: 0 B / 162 kB
  Space needed: 44.0 kB / 1862 MB available

Continue? [Y/n] y
Get:1 /home/elementary/io.elementary.settings.network_8.2.0_amd64.deb io.elementary.settings.network amd64 8.2.0 [162 kB]
dpkg: warning: downgrading io.elementary.settings.network (8.2.0+r1650+pkg859~daily~ubuntu9.1) to (8.2.0)
(Reading database ... 163230 files and directories currently installed.)
Preparing to unpack .../io.elementary.settings.network_8.2.0_amd64.deb ...
Unpacking io.elementary.settings.network (8.2.0) over (8.2.0+r1650+pkg859~daily~ubuntu9.1) ...
Setting up io.elementary.settings.network (8.2.0) ...
Notice: Download is performed unsandboxed as root as file '/home/elementary/io.elementary.settings.network_8.2.0_amd64.deb' couldn't be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
elementary@elementary:~$ 
```

</details>
